### PR TITLE
wrap and test H5L_create_external

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -1970,8 +1970,9 @@ for (jlname, h5name, outtype, argtypes, argsyms, ex_error) in
      (:h5i_get_name, :H5Iget_name, Cssize_t, (Hid, Ptr{UInt8}, Csize_t), (:obj_id, :buf, :buf_size), :(error("Error getting object name"))),
      (:h5i_get_ref, :H5Iget_ref, Cint, (Hid,), (:obj_id,), :(error("Error getting reference count"))),
      (:h5i_get_type, :H5Iget_type, Cint, (Hid,), (:obj_id,), :(error("Error getting type"))),
+     (:h5i_dec_ref, :H5Idec_ref, Cint, (Hid,), (:obj_id,), :(error("Error decementing reference"))),
      (:h5l_delete, :H5Ldelete, Herr, (Hid, Ptr{UInt8}, Hid), (:obj_id, :pathname, :lapl_id), :(error("Error deleting ", h5i_get_name(obj_id), "/", pathname))),
-     (:h5l_create_external, :H5Lcreate_hard_external, Herr, (Ptr{UInt8}, Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), (:target_file_name, :target_obj_name, :link_loc_id, :link_name, :lcpl_id, :lapl_id), :(error("Error creating external link ", link_name, " pointing to ", target_obj_name, " in file ", target_file_name))),
+     (:h5l_create_external, :H5Lcreate_external, Herr, (Ptr{UInt8}, Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), (:target_file_name, :target_obj_name, :link_loc_id, :link_name, :lcpl_id, :lapl_id), :(error("Error creating external link ", link_name, " pointing to ", target_obj_name, " in file ", target_file_name))),
      (:h5l_create_hard, :H5Lcreate_hard, Herr, (Hid, Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), (:obj_loc_id, :obj_name, :link_loc_id, :link_name, :lcpl_id, :lapl_id), :(error("Error creating hard link ", link_name, " pointing to ", obj_name))),
      (:h5l_create_soft, :H5Lcreate_soft, Herr, (Ptr{UInt8}, Hid, Ptr{UInt8}, Hid, Hid), (:target_path, :link_loc_id, :link_name, :lcpl_id, :lapl_id), :(error("Error creating soft link ", link_name, " pointing to ", target_path))),
      (:h5l_exists, :H5Lexists, Htri, (Hid, Ptr{UInt8}, Hid), (:loc_id, :pathname, :lapl_id), :(error("Cannot determine whether link ", h5i_get_name(loc_id), "/", pathname, " exists, check each item along the path"))),
@@ -2188,6 +2189,15 @@ const hdf5_prop_get_set = @compat Dict(
 )
 # properties that require chunks in order to work (e.g. any filter)
 const chunked_props = Set(["compress", "deflate", "blosc"])
+
+# external link
+"create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=HDF5.H5P_DEFAULT, lapl_id=HDF5.H5P.DEFAULT)
+Create an external link such that `source[source_relpath]` points to `target_path` within the file with path `target_filename`. Calls `[H5Lcreate_external](https://www.hdfgroup.org/HDF5/doc/RM/RM_H5L.html#Link-CreateExternal)`
+"
+@compat function create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=H5P_DEFAULT, lapl_id=H5P_DEFAULT)
+  h5l_create_external(target_filename, target_path, source.id, source_relpath, lcpl_id, lapl_id)
+end
+
 
 export
     # Types

--- a/test/external.jl
+++ b/test/external.jl
@@ -1,0 +1,44 @@
+using Base.Test
+using HDF5
+
+# roughly following https://www.hdfgroup.org/ftp/HDF5/current/src/unpacked/examples/h5_extlink.c
+source_file = h5open(tempname(), "w")
+agroup = g_create(source_file, "agroup")
+target_file = h5open(tempname(), "w")
+target_group = g_create(target_file, "target_group")
+target_group["abc"]="abc"
+target_group["1"]=1
+target_group["1.1"]=1.1
+close(target_file)
+
+# create external link such that source_file["ext_link"] points to target_file["target_group"]
+# test both an HDF5File and an HDF5Group for first argument
+HDF5.create_external(source_file, "ext_link", target_file.filename, "target_group")
+HDF5.create_external(agroup, "ext_link", target_file.filename, "target_group")
+# write some things via the external link
+new_group = g_create(source_file["ext_link"], "new_group")
+new_group["abc"]="abc"
+new_group["1"]=1
+new_group["1.1"]=1.1
+
+# read things from target_group via exernal link created with HDF5File argument
+group = source_file["ext_link"]
+@test read(group["abc"])=="abc"
+@test read(group["1"])==1
+@test read(group["1.1"])==1.1
+# read things from target_group via the external link created with HDF5Group argument
+groupalt = source_file["agroup/ext_link"]
+@test read(groupalt["abc"])=="abc"
+@test read(groupalt["1"])==1
+@test read(groupalt["1.1"])==1.1
+close(source_file)
+
+##### tests that should be included but don't work
+# when ggggggggg restarts julia and keeps track of target_file.filename,
+# these tests succeed
+# reopening the target_file crashes due to "file close degree doesn't match"
+# target_file = h5open(target_file.filename, "r")
+# group2 = target_file["target_group"]["new_group"]
+# @test read(group2["abc"])=="abc"
+# @test read(group2["1"])==1
+# @test read(group2["1.1"])==1.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,5 +6,6 @@ runtest("plain.jl")
 runtest("readremote.jl")
 runtest("extend_test.jl")
 runtest("gc.jl")
+runtest("external.jl")
 
 nothing


### PR DESCRIPTION
As far as I can tell `H5Lcreate_hard_external` doesn't exist. See #272 for discussion on why some of the tests are commented out. `H5Idec_ref` isn't necessary for this, but I think is of the solution for getting the commented out tests to work.