### PR TITLE
Use deflate as default compression mechanism

### DIFF
--- a/doc/hdf5.md
+++ b/doc/hdf5.md
@@ -96,23 +96,33 @@ g["mydataset"] = rand(3,5)
 write(g, "mydataset", rand(3,5))
 ```
 
-You can also optionally "chunk" and compress your data. For example,
+You can also optionally "chunk" and/or compress your data. For example,
 
 ```julia
 A = rand(100,100)
-g["A", "chunk", (5,5), "compress", 3] = A
+g["A", "chunk", (5,5)] = A
 ```
 
-stores the matrix `A` in 5-by-5 chunks and uses a compression level
-`3`. Instead of `"compress"`, you can use `"deflate"` to specify
-[deflate/zlib](http://en.wikipedia.org/wiki/DEFLATE) compression, or
-`"blosc"` to specify [Blosc](http://www.blosc.org/) compress. Blosc is
-generally much faster than deflate, however, files with deflate compression are more 
-portable. Currently, `"compress"`
-corresponds to `"blosc"`. Chunking can be useful if you will typically
-extract small segments of an array.  A heuristic chunking is
-automatically used if you specify compression but don't specify
-chunking.
+stores the matrix `A` in 5-by-5 chunks. Chunking improves efficiency if you
+write or extract small segments or slices of an array, if these are not stored
+contiguously.
+
+```julia
+A = rand(100,100)
+g1["A", "chunk", (5,5), "compress", 3] = A
+g2["A", "chunk", (5,5), "shuffle", (), "deflate", 3] = A
+g3["A", "chunk", (5,5), "blosc", 3] = A
+```
+
+Standard compression in HDF5 (`"compress"`) corresponds to (`"deflate"`) and
+uses the [deflate/zlib](http://en.wikipedia.org/wiki/DEFLATE) algorithm. The
+deflate algorithm is often more efficient if prefixed by a `"shuffle"` filter.
+Blosc is generally much faster than deflate -- however, reading Blosc-compressed
+HDF5 files require Blosc to be installed. This is the case for Julia, but often
+not for vanilla HDF5 distributions that may be used outside Julia. (In this
+case, the structure of the HDF5 file is still accessible, but compressed
+datasets cannot be read.) Compression requires chunking, and heuristic chunking
+is automatically used if you specify compression but don't specify chunking.
 
 It is also possible to write to subsets of an on-disk HDF5 dataset. This is
 useful to incrementally save to very large datasets you don't want to keep in

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -1910,6 +1910,7 @@ for (jlname, h5name, outtype, argtypes, argsyms, msg) in
      (:h5p_set_layout, :H5Pset_layout, Herr, (Hid, Cint), (:plist_id, :setting), "Error setting layout"),
      (:h5p_set_libver_bounds, :H5Pset_libver_bounds, Herr, (Hid, Cint, Cint), (:fapl_id, :libver_low, :libver_high), "Error setting library version bounds"),
      (:h5p_set_local_heap_size_hint, :H5Pset_local_heap_size_hint, Herr, (Hid, Cuint), (:fapl_id, :size_hint), "Error setting local heap size hint"),
+     (:h5p_set_shuffle, :H5Pset_shuffle, Herr, (Hid,), (:plist_id,), "Error enabling shuffle filter"),
      (:h5p_set_userblock, :H5Pset_userblock, Herr, (Hid, Hsize), (:plist_id, :len), "Error setting userblock"),
      (:h5s_close, :H5Sclose, Herr, (Hid,), (:space_id,), "Error closing dataspace"),
      (:h5s_select_hyperslab, :H5Sselect_hyperslab, Herr, (Hid, Cint, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}, Ptr{Hsize}), (:dspace_id, :seloper, :start, :stride, :count, :block), "Error selecting hyperslab"),
@@ -2181,14 +2182,15 @@ end
 const hdf5_prop_get_set = @compat Dict(
     "chunk"         => (get_chunk, set_chunk),
     "fclose_degree" => (get_fclose_degree, h5p_set_fclose_degree),
-    "compress"      => (nothing, h5p_set_blosc),
+    "compress"      => (nothing, h5p_set_deflate),
     "deflate"       => (nothing, h5p_set_deflate),
     "blosc"         => (nothing, h5p_set_blosc),
     "layout"        => (h5p_get_layout, h5p_set_layout),
+    "shuffle"       => (nothing, h5p_set_shuffle),
     "userblock"     => (get_userblock, h5p_set_userblock),
 )
 # properties that require chunks in order to work (e.g. any filter)
-const chunked_props = Set(["compress", "deflate", "blosc"])
+const chunked_props = Set(["compress", "deflate", "blosc", "shuffle"])
 
 # external link
 "create_external(source::Union{HDF5File, HDF5Group}, source_relpath, target_filename, target_path; lcpl_id=HDF5.H5P_DEFAULT, lapl_id=HDF5.H5P.DEFAULT)


### PR DESCRIPTION
Make "compress" use the "deflate" compression algorithm. "blosc" continues to use Blosc for compression. This makes HDF5 files written with "compress" be portable.