### PR TITLE
Add aliases on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ end
 
 @windows_only begin
     using WinRPM
-    hdf5 = library_dependency("libhdf5")
+    hdf5 = library_dependency("libhdf5", aliases = ["hdf5_w64", "hdf5"])
     provides(WinRPM.RPM, "hdf5", hdf5, os = :Windows )
 end
 


### PR DESCRIPTION
Users that have installed GMT of the binaries from Gisinternals will have hdf5 dlls installed in their systems. This aliases make use of them.