### PR TITLE
Support HDF5 1.10

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,7 +21,7 @@ end
     provides(Homebrew.HB, "hdf5", hdf5, os = :Darwin )
 end
 
-provides(Sources, URI("http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.16.tar.gz"), hdf5)
+provides(Sources, URI("http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0/src/hdf5-1.10.0.tar.gz"), hdf5)
 provides(BuildProcess, Autotools(libtarget = "libhdf5.la"), hdf5)
 
 @compat @BinDeps.install Dict(:libhdf5 => :libhdf5)

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -41,7 +41,7 @@ function h5_get_libversion()
     if status < 0
         error("Error getting HDF5 library version")
     end
-    Int(_majnum[1]), Int(_minnum[1]), Int(_relnum[1])
+    convert(Int,_majnum[1]), convert(Int,_minnum[1]), convert(Int,_relnum[1])
 end
 
 _libversion = h5_get_libversion()

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -64,7 +64,7 @@ typealias Haddr       UInt64
 # Function to extract exported library constants
 # Kudos to the library developers for making these available this way!
 const libhdf5handle = Libdl.dlopen(libhdf5)
-read_const(sym::Symbol) = unsafe_load(convert(Ptr{Cint}, Libdl.dlsym(libhdf5handle, sym)))
+read_const(sym::Symbol) = unsafe_load(convert(Ptr{Hid}, Libdl.dlsym(libhdf5handle, sym)))
 
 # iteration order constants
 const H5_ITER_UNKNOWN = -1

--- a/src/plain.jl
+++ b/src/plain.jl
@@ -41,7 +41,7 @@ function h5_get_libversion()
     if status < 0
         error("Error getting HDF5 library version")
     end
-    return _majnum[1], _minnum[1], _relnum[1]
+    Int(_majnum[1]), Int(_minnum[1]), Int(_relnum[1])
 end
 
 _libversion = h5_get_libversion()


### PR DESCRIPTION
A new version of HDF5 was recently released. It now uses a 64-bit integer for hid_t.