### PR TITLE
Define `rehash!` at module-level

### DIFF
--- a/src/plain.jl
+++ b/src/plain.jl
@@ -582,7 +582,7 @@ function h5open(filename::AbstractString, mode::AbstractString="r", pv...)
         end
         p[thisname] = pv[i+1]
     end
-    modes = 
+    modes =
         mode == "r"  ? (true,  false, false, false, false) :
         mode == "r+" ? (true,  true,  false, false, true ) :
         mode == "w"  ? (false, true,  true,  true,  false) :
@@ -2350,6 +2350,13 @@ export
     write,
     @write
 
+# Define globally because JLD uses this, too
+if VERSION < v"0.4.0-dev+2014"
+    const rehash! = Base.rehash
+else
+    const rehash! = Base.rehash!
+end
+
 # Across initializations of the library, the id of various properties
 # will change. So don't hard-code the id (important for precompilation)
 const ASCII_LINK_PROPERTIES = Array(HDF5Properties)
@@ -2379,12 +2386,6 @@ function __init__()
     h5p_set_char_encoding(ASCII_ATTRIBUTE_PROPERTIES[].id, cset(ASCIIString))
     UTF8_ATTRIBUTE_PROPERTIES[] = p_create(H5P_ATTRIBUTE_CREATE)
     h5p_set_char_encoding(UTF8_ATTRIBUTE_PROPERTIES[].id, cset(UTF8String))
-
-    if VERSION < v"0.4.0-dev+2014"
-        rehash! = Base.rehash
-    else
-        rehash! = Base.rehash!
-    end
 
     rehash!(hdf5_type_map, length(hdf5_type_map.keys))
     rehash!(hdf5_prop_get_set, length(hdf5_prop_get_set.keys))

--- a/test/plain.jl
+++ b/test/plain.jl
@@ -95,7 +95,7 @@ d[3:5] = 3:5
 f["deleteme"] = 17.2
 close(f)
 # Test the h5read/write interface, with attributes
-W = reshape(1:120, 15, 8)
+W = copy(reshape(1:120, 15, 8))
 Wa = @compat Dict("a"=>1, "b"=>2)
 h5write(fn, "newgroup/W", W)
 h5writeattr(fn, "newgroup/W", Wa)


### PR DESCRIPTION
It's [called by JLD](https://github.com/JuliaLang/JLD.jl/blob/12fc3bb3ea654534616848545e787574a0b2230f/src/JLD.jl#L1271-L1272), too. This moves it back to global scope in HDF5; alternatively, we could duplicate that logic in JLD.
